### PR TITLE
Forth standard subtraction order

### DIFF
--- a/colorforth.c
+++ b/colorforth.c
@@ -273,7 +273,7 @@ execute_(struct state *s, struct entry *entry)
       {
         const cell n1 = pop(s);
         const cell n2 = pop(s);
-        push(s, n1 - n2);
+        push(s, n2 - n1);
         break;
       }
       


### PR DESCRIPTION
Don't know if the subtraction order is intended. But it is inverted compared to [Forth standard](https://forth-standard.org/standard/core/Minus) :
**colorForth**
```forth
10 3 -
-7
```

**Gforth**
```forth
10 3 -
7
```